### PR TITLE
[16.0] [FIX] medical_financial_coverage_request: Fix error adding service

### DIFF
--- a/medical_financial_coverage_request/wizard/medical_careplan_add_plan_definition.py
+++ b/medical_financial_coverage_request/wizard/medical_careplan_add_plan_definition.py
@@ -22,7 +22,9 @@ class MedicalCareplanAddPlanDefinition(models.TransientModel):
     agreement_ids = fields.Many2many(
         "medical.coverage.agreement", compute="_compute_agreements"
     )
-    agreement_line_id = fields.Many2one("medical.coverage.agreement.item")
+    agreement_line_id = fields.Many2one(
+        "medical.coverage.agreement.item",
+    )
     product_id = fields.Many2one(
         "product.product",
         related="agreement_line_id.product_id",

--- a/medical_financial_coverage_request/wizard/medical_careplan_add_plan_definition_views.xml
+++ b/medical_financial_coverage_request/wizard/medical_careplan_add_plan_definition_views.xml
@@ -21,6 +21,7 @@
                     name="agreement_line_id"
                     options="{'no_create': True}"
                     domain="[('coverage_agreement_id', 'in', agreement_ids),('plan_definition_id', '!=', False)]"
+                    required="1"
                 />
                 <field name="center_id" invisible="1" />
                 <field name="patient_id" invisible="1" />


### PR DESCRIPTION
Si desde un encounter le damos al botón add service y solo establecemos los campos obligatorios en el asistente se produce el siguiente error:

![image](https://github.com/user-attachments/assets/b1cae66a-2381-48b1-822c-c8d49e64b33a)

El error en código se produce al intentar ejecutar la función execute_plan_definition() en el modelo medical.add.plan.definition del módulo medical_workflow ya que esta función tiene ensure_one() y el plan definition sobre el que se ejecuta es False. Este plan_definition_id viene establecido en el wizard de medical_financial_coverage_request por la relación con agreement_line_id por lo tanto **debe ser establecido agreement_line_id y este tenga un plan_definition_id**

