### PR TITLE
[FIX] cb_medical_workflow_activity: Avoid search himself

### DIFF
--- a/cb_medical_workflow_activity/models/workflow_activity_definition.py
+++ b/cb_medical_workflow_activity/models/workflow_activity_definition.py
@@ -22,7 +22,15 @@ class ActivityDefinition(models.Model):
         for rec in self.filtered(lambda r: r.service_id):
             if rec.service_id.type != "service":
                 raise ValidationError(_("Activite are only allowed for services"))
-            if self.search([("service_id", "=", rec.service_id.id)], limit=1):
+            if self.search(
+                [("service_id", "=", rec.service_id.id), ("id", "!=", rec.id)], limit=1
+            ):
                 raise ValidationError(_("Only one activity is allowed for service"))
-            if self.search([("service_tmpl_id", "=", rec.service_tmpl_id.id)], limit=1):
+            if self.search(
+                [
+                    ("service_tmpl_id", "=", rec.service_tmpl_id.id),
+                    ("id", "!=", rec.id),
+                ],
+                limit=1,
+            ):
                 raise ValidationError(_("Only one activity is allowed for service"))


### PR DESCRIPTION
Así evitamos que al recorrer todos los recorset busque un workflow.activity.definition con el mismo servicio, pero que no sea el mismo que estamos recorriendo.

@etobella 