### PR TITLE
[16.0][FIX] pos_validation: agnt_line

### DIFF
--- a/pos_validation/models/account_invoice_line_agent.py
+++ b/pos_validation/models/account_invoice_line_agent.py
@@ -11,7 +11,7 @@ class AccountInvoiceLineAgent(models.Model):
     def action_settlement_invoice(self):
         self.ensure_one()
         invoices = (
-            self.agent_line.mapped("settlement_id")
+            self.settlement_line_ids.mapped("settlement_id")
             .filtered(lambda r: r.state != "cancel")
             .mapped("invoice_line_ids.move_id")
         )


### PR DESCRIPTION
cambio de nombre, en el modelo "account.invoice.line.agent" ahora está:
```
    settlement_line_ids = fields.One2many(
        comodel_name="commission.settlement.line",
        inverse_name="invoice_agent_line_id",
    )
```