### PR TITLE
[16.0][FIX] cb_medical_diagnostic_report: fix state to fhir_state

### DIFF
--- a/cb_medical_diagnostic_report/views/medical_diagnostic_report.xml
+++ b/cb_medical_diagnostic_report/views/medical_diagnostic_report.xml
@@ -29,7 +29,7 @@
                     name="copy_action"
                     type="object"
                     string="Duplicate"
-                    states="final,cancelled"
+                    attrs="{'invisible': [('fhir_state', 'not in', ['final', 'cancelled'])]}"
                     confirm="Are you sure you want to duplicate this report?"
                 />
             </xpath>


### PR DESCRIPTION
The field which we want to reference is fhir_state not state 
Already done it in production

@etobella 