### PR TITLE
[16.0][FIX] pos_validation: sudo to cancel

### DIFF
--- a/pos_validation/models/medical_request.py
+++ b/pos_validation/models/medical_request.py
@@ -83,7 +83,7 @@ class MedicalRequest(models.AbstractModel):
         res = super().cancel()
         if lines:
             # Unlink shouldn't use sudo for safety
-            self.sale_order_line_ids.unlink()
+            self.sale_order_line_ids.sudo().unlink()
         return res
 
     def cancel_values(self):


### PR DESCRIPTION
Veo que hay un comentario sobre no poder eliminar el archivo usando sudo, pero hay una incidencia que cuando un doctor intenta cancelar una ficha. 

https://github.com/tegin/cb-medical/commit/234cdbb383d5966bbd8f6a12973dbe6794202a1d

```
procedure_request_id: XXXXXX
user_id: XXX
remote_id: XXX (siempre remote_auto)

07:01:18,695 [INFO] [quartzScheduler_Worker-2] XMLRPC_Odoo - procedure_request_cancel_cb (REQUEST): XXXXXX _ XXX _ XXX
07:01:18,752 [INFO] [quartzScheduler_Worker-2] XMLRPC_Odoo - procedure_request_cancel_cb (RESPONSE): {xmlrpc_message=No puede ingresar a los registros 'LÃ­nea de orden de ventas' (sale.order.line)

Se permite esta operaciÃ³n para los grupos siguientes:
- Contabilidad y Finanzas/FacturaciÃ³n
- Contabilidad y Finanzas/Mostrar caracterÃ­sticas de contabilidad completas
- Contabilidad y Finanzas/Mostrar funciones de contabilidad: solo lectura
- FabricaciÃ³n/Usuario
- Inventario/Usuario
- Tipos de Usuario/Portal
- Ventas/Usuario: Solo mostrar documentos propios

```
