### PR TITLE
[16.0] [IMP] cb_medical_diagnostic_report: increase image width

### DIFF
--- a/cb_medical_diagnostic_report/reports/medical_diagnostic_report_template.xml
+++ b/cb_medical_diagnostic_report/reports/medical_diagnostic_report_template.xml
@@ -33,9 +33,9 @@
                         style="text-align:center"
                     >
                         <img
-                            class="image"
+                            class="image p-1"
                             t-att-src="'data:%s;base64,%s' % (image.file.mimetype, image.file.attachment.datas.decode('utf-8'))"
-                            style="border:auto; max-width:50%;"
+                            style="border:auto; max-width:100%;"
                         />
                         <t t-if="image.description">
                             <br />


### PR DESCRIPTION
Increase the image width on medical reports

Before / after

<img width="800" height="355" alt="image" src="https://github.com/user-attachments/assets/db5ed8cb-331a-459d-ab89-28f36e456e74" />
